### PR TITLE
Fix issue

### DIFF
--- a/Client/Main.cs
+++ b/Client/Main.cs
@@ -316,6 +316,9 @@ namespace GTACoOp
         private void RebuildPlayersList()
         {
             _playersMenu.Clear();
+            
+            if (Opponents == null ) return;
+
             var list = new List<SyncPed>(Opponents.Select(pair => pair.Value));
 
             foreach (var ped in list)


### PR DESCRIPTION
If player isn't in an session when click in "Active Players" menu,
script will crash because the "Oppenets" variable is null