### PR TITLE
Fix Creating accounts

### DIFF
--- a/AdminTools/MainFilterscript.cs
+++ b/AdminTools/MainFilterscript.cs
@@ -338,7 +338,7 @@ namespace AdminTools
                 var accObject = new Account()
                 {
                     Level = Privilege.User,
-                    Name = sender.Name,
+                    Name = sender.DisplayName,
                     Password = password,
                     Ban = null
                 };


### PR DESCRIPTION
Fix Creating accounts with DisplayName instead of account name.
Now people with other DisplayName Cannot create a lot of Accounts with
the same SocialClub Name